### PR TITLE
Metadata を `layout.tsx` に追加しました

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,8 @@
-'use client';
+'use strict';
 
 import { Inter } from 'next/font/google';
 import '@/styles/globals.css';
-import { useEffect, useState } from 'react';
+import { Metadata } from 'next';
 
 // Component
 import { Header } from '@/stories/Header';
@@ -11,35 +11,22 @@ export const runtime = 'edge';
 
 const inter = Inter({ subsets: ['latin'] });
 
+export const metadata: Metadata = {
+  title: 'たまりば',
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const [isDesktop, setIsDesktop] = useState(true);
-
-  useEffect(() => {
-    const handleResize = () => {
-      const width = window.innerWidth;
-      setIsDesktop(width > 768);
-    };
-
-    handleResize(); // Call the function initially
-
-    window.addEventListener('resize', handleResize); // Add event listener for window resize
-
-    return () => {
-      window.removeEventListener('resize', handleResize); // Clean up the event listener on component unmount
-    };
-  }, []);
-
   return (
     <html lang="en">
       <body className={inter.className}>
         <div className="flex h-screen w-screen flex-col overflow-hidden">
-          <Header desktop={isDesktop} />
+          <Header />
           {children}
-          <Footer className="bg-white" desktop={isDesktop} />
+          <Footer className="bg-white" />
         </div>
       </body>
     </html>

--- a/src/stories/Footer.stories.ts
+++ b/src/stories/Footer.stories.ts
@@ -19,6 +19,5 @@ export const Primary: Story = {
   args: {
     path: '/',
     fixed: true,
-    desktop: false,
   },
 };

--- a/src/stories/Footer.tsx
+++ b/src/stories/Footer.tsx
@@ -1,7 +1,9 @@
+'use client';
+
 import React from 'react';
 import { Items } from './Items';
 import { tv } from 'tailwind-variants';
-
+import useIsDesktop from '@/utils/useIsDesktop';
 import { Noto_Sans_JP } from 'next/font/google';
 import { Label } from './Label';
 
@@ -15,25 +17,28 @@ interface FooterProps {
   path?: string;
   fixed?: boolean;
   className?: string;
-  desktop?: boolean;
 }
 
 const year = new Date().getFullYear();
 
-export const Footer = ({ path, fixed, className, desktop = false }: FooterProps) => (
-  <>
-    <footer
-      className={`${footer({ className: `${fixed && 'fixed bottom-0'} ${className} ${desktop && 'hidden'}` })} ${NotoSansJP.className}`}
-    >
-      <div className="flex w-full max-w-sm justify-between">
-        <Items />
-      </div>
-    </footer>
-    <footer>
-      {/* Copylight */}
-      <div className={`${desktop ? 'flex' : 'hidden'} justify-start p-6 px-5`}>
-        <Label variant="small">{`© ${year} たまりば`}</Label>
-      </div>
-    </footer>
-  </>
-);
+export const Footer = ({ path, fixed, className }: FooterProps) => {
+  const isDesktop = useIsDesktop();
+
+  return (
+    <>
+      <footer
+        className={`${footer({ className: `${fixed && 'fixed bottom-0'} ${className} ${isDesktop && 'hidden'}` })} ${NotoSansJP.className}`}
+      >
+        <div className="flex w-full max-w-sm justify-between">
+          <Items />
+        </div>
+      </footer>
+      <footer>
+        {/* Copylight */}
+        <div className={`${isDesktop ? 'flex' : 'hidden'} justify-start p-6 px-5`}>
+          <Label variant="small">{`© ${year} たまりば`}</Label>
+        </div>
+      </footer>
+    </>
+  );
+};

--- a/src/stories/Footer.tsx
+++ b/src/stories/Footer.tsx
@@ -11,6 +11,11 @@ const NotoSansJP = Noto_Sans_JP({ subsets: ['latin'] });
 
 const footer = tv({
   base: `flex w-full justify-center border-t border-border pb-6 pt-5`,
+  variants: {
+    isDesktop: {
+      true: 'hidden',
+    },
+  },
 });
 
 interface FooterProps {
@@ -28,7 +33,8 @@ export const Footer = ({ path, fixed, className }: FooterProps) => {
     <>
       <footer
         className={footer({
-          className: `${fixed && 'fixed bottom-0'} ${className} ${isDesktop && 'hidden'} ${NotoSansJP.className}`,
+          className: `${fixed && 'fixed bottom-0'} ${className} ${NotoSansJP.className}`,
+          isDesktop,
         })}
       >
         <div className="flex w-full max-w-sm justify-between">

--- a/src/stories/Footer.tsx
+++ b/src/stories/Footer.tsx
@@ -15,6 +15,9 @@ const footer = tv({
     isDesktop: {
       true: 'hidden',
     },
+    fixed: {
+      true: 'fixed bottom-0',
+    },
   },
 });
 
@@ -28,15 +31,11 @@ const year = new Date().getFullYear();
 
 export const Footer = ({ path, fixed, className }: FooterProps) => {
   const isDesktop = useIsDesktop();
+  className = `${className} ${NotoSansJP.className}`;
 
   return (
     <>
-      <footer
-        className={footer({
-          className: `${fixed && 'fixed bottom-0'} ${className} ${NotoSansJP.className}`,
-          isDesktop,
-        })}
-      >
+      <footer className={footer({ className, isDesktop, fixed })}>
         <div className="flex w-full max-w-sm justify-between">
           <Items />
         </div>

--- a/src/stories/Footer.tsx
+++ b/src/stories/Footer.tsx
@@ -27,7 +27,9 @@ export const Footer = ({ path, fixed, className }: FooterProps) => {
   return (
     <>
       <footer
-        className={`${footer({ className: `${fixed && 'fixed bottom-0'} ${className} ${isDesktop && 'hidden'}` })} ${NotoSansJP.className}`}
+        className={footer({
+          className: `${fixed && 'fixed bottom-0'} ${className} ${isDesktop && 'hidden'} ${NotoSansJP.className}`,
+        })}
       >
         <div className="flex w-full max-w-sm justify-between">
           <Items />

--- a/src/stories/Header.tsx
+++ b/src/stories/Header.tsx
@@ -1,7 +1,10 @@
+'use client';
+
 import React from 'react';
 import { Label } from './Label';
 import { tv } from 'tailwind-variants';
 import { Items } from './Items';
+import useIsDesktop from '@/utils/useIsDesktop';
 
 import { Noto_Sans_JP } from 'next/font/google';
 
@@ -10,7 +13,7 @@ const NotoSansJP = Noto_Sans_JP({ subsets: ['latin'] });
 const footer = tv({
   base: `flex w-full justify-center border-b border-border py-4`,
   variants: {
-    desktop: {
+    isDesktop: {
       true: `px-5`,
     },
   },
@@ -20,20 +23,23 @@ interface FooterProps {
   title?: string;
   fixed?: boolean;
   className?: string;
-  desktop?: boolean;
 }
 
-export const Header = ({ title, fixed, className, desktop = false }: FooterProps) => (
-  <header
-    className={`${footer({ className: `${fixed && 'fixed top-0'} ${className}`, desktop })} ${NotoSansJP.className}`}
-  >
-    <div className="flex w-full max-w-sm justify-between p-1 md:max-w-full">
-      <Label variant="large">{title ?? 'たまりば'}</Label>
-      {desktop && (
-        <div className="flex">
-          <Items hideIcon={true} />
-        </div>
-      )}
-    </div>
-  </header>
-);
+export const Header = ({ title, fixed, className }: FooterProps) => {
+  const isDesktop = useIsDesktop();
+
+  return (
+    <header
+      className={`${footer({ className: `${fixed && 'fixed top-0'} ${className}`, isDesktop })} ${NotoSansJP.className}`}
+    >
+      <div className="flex w-full max-w-sm justify-between p-1 md:max-w-full">
+        <Label variant="large">{title ?? 'たまりば'}</Label>
+        {isDesktop && (
+          <div className="flex">
+            <Items hideIcon={true} />
+          </div>
+        )}
+      </div>
+    </header>
+  );
+};

--- a/src/stories/Header.tsx
+++ b/src/stories/Header.tsx
@@ -10,7 +10,7 @@ import { Noto_Sans_JP } from 'next/font/google';
 
 const NotoSansJP = Noto_Sans_JP({ subsets: ['latin'] });
 
-const footer = tv({
+const header = tv({
   base: `flex w-full justify-center border-b border-border py-4`,
   variants: {
     isDesktop: {
@@ -19,18 +19,18 @@ const footer = tv({
   },
 });
 
-interface FooterProps {
+interface HeaderProps {
   title?: string;
   fixed?: boolean;
   className?: string;
 }
 
-export const Header = ({ title, fixed, className }: FooterProps) => {
+export const Header = ({ title, fixed, className }: HeaderProps) => {
   const isDesktop = useIsDesktop();
 
   return (
     <header
-      className={`${footer({ className: `${fixed && 'fixed top-0'} ${className}`, isDesktop })} ${NotoSansJP.className}`}
+      className={`${header({ className: `${fixed && 'fixed top-0'} ${className}`, isDesktop })} ${NotoSansJP.className}`}
     >
       <div className="flex w-full max-w-sm justify-between p-1 md:max-w-full">
         <Label variant="large">{title ?? 'たまりば'}</Label>

--- a/src/utils/useIsDesktop.ts
+++ b/src/utils/useIsDesktop.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export default function useIsDesktop() {
+  const [isDesktop, setIsDesktop] = useState(true);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const width = window.innerWidth;
+      setIsDesktop(width > 768);
+    };
+
+    handleResize(); // Call the function initially
+
+    window.addEventListener('resize', handleResize); // Add event listener for window resize
+
+    return () => {
+      window.removeEventListener('resize', handleResize); // Clean up the event listener on component unmount
+    };
+  }, []);
+
+  return isDesktop;
+}


### PR DESCRIPTION
### 説明
`layout.tsx` に `export const metadata: Metadata = {}` を追加しました
その際に 'use client' から 'use strict' に変更したため、下記のファイルを追加または変更させていただきました

### 追加
- [useIsDesktop.ts](https://github.com/tech-creative-club/tama-river-client/compare/feature/17?expand=1#diff-2554b24905eb2c2d13506e4709819bb98fa1bec44d39ee87d3e012fb6366d4bb)

### 変更
- layout.tsx, Footer.tsx, Header.tsx